### PR TITLE
feat(style-tailwind): updated tailwind config with design tokens

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-	"cSpell.words": ["Abeg", "clsx", "signin", "signup", "zxcvbn"]
+	"cSpell.words": ["Abeg", "clsx", "signin", "signup", "zxcvbn"],
+	"tailwindCSS.rootFontSize": 10
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-	"cSpell.words": ["Abeg", "clsx", "signin", "signup", "zxcvbn"],
-	"tailwindCSS.rootFontSize": 10
+	"cSpell.words": ["Abeg", "clsx", "signin", "signup", "zxcvbn"]
 }

--- a/lib/helpers/cn.ts
+++ b/lib/helpers/cn.ts
@@ -1,5 +1,24 @@
-import clsx, {type ClassValue} from 'clsx'
-import {twMerge} from 'tailwind-merge'
+import twConfig from "@/tailwind.config";
+import clsx, { type ClassValue } from "clsx";
+import { extendTailwindMerge } from "tailwind-merge";
 
-export const cn = (...classNames: ClassValue[]): string =>
-	twMerge(clsx(classNames))
+const themeObject = twConfig.theme.extend;
+
+const customTwMerge = extendTailwindMerge({
+	extend: {
+		classGroups: {
+			"font-size": Object.keys(themeObject.fontSize).map(
+				(key) => `text-${key}`
+			),
+
+			rounded: Object.keys(themeObject.borderRadius).map(
+				(key) => `rounded-${key}`
+			),
+		},
+	},
+});
+
+const cn = (...classNames: ClassValue[]): string =>
+	customTwMerge(clsx(classNames));
+
+export { cn };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,17 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
-html {
-	font-size: 62.5%;
-}
-
-body {
-	font-size: 1.6rem;
-}
 
 html,
 body {
 	min-height: 100%;
+}
+
+html:has([data-rem-reset]) {
+	font-size: 62.5%;
+}
+
+body:has([data-rem-reset]) {
+	font-size: 1.6rem;
 }
 
 input[type="number"] {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,61 +2,72 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+	font-size: 62.5%;
+}
+
+body {
+	font-size: 1.6rem;
+}
+
 html,
 body {
-  height: 100%;
+	min-height: 100%;
 }
 
 input[type="number"] {
-  -webkit-appearance: textfield;
+	-webkit-appearance: textfield;
 }
 
 /* Remove the inner spinner */
 input[type="number"]::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
+	-webkit-appearance: none;
+	margin: 0;
 }
 
 /* Remove the outer spinner (for Firefox) */
 input[type="number"]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
+	-webkit-appearance: none;
+	margin: 0;
 }
 
 #__next {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
 }
+
 input[type="number"] {
-  -moz-appearance: textfield;
-  appearance: textfield;
+	-moz-appearance: textfield;
+	appearance: textfield;
 }
+
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
+	-webkit-appearance: none;
+	margin: 0;
 }
+
 input:-webkit-autofill,
 input:-webkit-autofill:focus {
-  transition:
-    background-color 600000s 0s,
-    color 600000s 0s;
+	transition:
+		background-color 600000s 0s,
+		color 600000s 0s;
 }
 
 input[data-autocompleted] {
-  background-color: transparent !important;
+	background-color: transparent !important;
 }
 
 .balancedText {
-  text-wrap: balance;
+	text-wrap: balance;
 }
 
-/* 
+/*
 Storybook Preview Body Background Color intentionally set to edge against machines dark modes
 TODO: Configure a dark mode support system for stories at some point
 */
 .sb-show-main {
-  background: white;
+	background: white;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,7 +12,7 @@ body {
 
 html,
 body {
-	min-height: 100%;
+	height: 100%;
 }
 
 input[type="number"] {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,7 +12,7 @@ body {
 
 html,
 body {
-	height: 100%;
+	min-height: 100%;
 }
 
 input[type="number"] {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,102 +1,184 @@
-import type {Config} from 'tailwindcss'
-import plugin from 'tailwindcss/plugin'
+import type { Config } from "tailwindcss";
+import plugin from "tailwindcss/plugin";
 
-const config: Config = {
+const config = {
 	content: [
-		'./pages/**/*.{js,ts,jsx,tsx,mdx}',
-		'./layouts/**/*.{js,ts,jsx,tsx,mdx}',
-		'./components/**/*.{js,ts,jsx,tsx,mdx}',
-		'./app/**/*.{js,ts,jsx,tsx,mdx}',
-		'./stories/**/*.{js,ts,jsx,tsx,mdx}',
+		"./pages/**/*.{js,ts,jsx,tsx,mdx}",
+		"./layouts/**/*.{js,ts,jsx,tsx,mdx}",
+		"./components/**/*.{js,ts,jsx,tsx,mdx}",
+		"./app/**/*.{js,ts,jsx,tsx,mdx}",
 	],
+
 	theme: {
 		extend: {
-			screens: {
-				'3xl': '2000px',
+			spacing: {
+				0.3: "0.3rem",
+				0.4: "0.4rem",
+				0.8: "0.8rem",
+				1: "1rem",
+				1.2: "1.2rem",
+				1.3: "1.3rem",
+				1.4: "1.4rem",
+				1.5: "1.5rem",
+				1.6: "1.6rem",
+				1.9: "1.9rem",
+				2: "2rem",
+				2.2: "2.2rem",
+				2.3: "2.3rem",
+				2.4: "2.4rem",
+				2.6: "2.6rem",
+				2.8: "2.8rem",
+				3: "3rem",
+				3.2: "3.2rem",
+				3.4: "3.4rem",
+				4.8: "4.8rem",
+				5.5: "5.5rem",
+				6.2: "6.2rem",
+				7: "7rem",
+				10: "10rem",
+				21.3: "21.3rem",
 			},
+
+			borderRadius: {
+				6: "6px",
+				8: "8px",
+				10: "10px",
+			},
+
+			fontSize: {
+				1: "1rem",
+				1.2: "1.2rem",
+				1.4: "1.4rem",
+				1.6: "1.6rem",
+				2: "2rem",
+				2.4: "2.4rem",
+			},
+
+			screens: {
+				"3xl": "2000px",
+			},
+
 			backgroundImage: {
 				contours: "url('/assets/images/shared/bg-contours.png')",
-				'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-				'gradient-conic':
-					'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+				"contours-old": "url('/assets/images/shared/contours-old.png')",
+				"gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
+				"gradient-conic":
+					"conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
 			},
+
 			boxShadow: {
-				'auth-layout-shadow': ' 0px 2px 32px 0px rgba(0, 0, 0, 0.08)',
+				"auth-layout-shadow": "0px 2px 32px 0px rgba(0, 0, 0, 0.08)",
 			},
+
 			colors: {
-				text: '#1B1818',
-				successText: '#484848',
-				formBtn: '#008080',
-				validationMsg: '#268384',
+				text: "#1B1818",
+				successText: "#484848",
+				placeholder: "#8D8B8B",
+				unfocused: "#A8CCCC",
+				formBtn: "#008080",
+				semiWhite: "#E6EAEE",
+				validationMsg: "#268384",
+				popover: "hsl(0 0% 100%)",
+				"popover-foreground": "hsl(222.2 47.4% 11.2%)",
+				accent: "hsl(210 40% 96.1%)",
+				"accent-foreground": "hsl(222.2 47.4% 11.2%)",
+				input: "hsl(214.3 31.8% 91.4%)",
+				ring: "hsl(215 20.2% 65.1%)",
+				muted: "hsl(210 40% 96.1%)",
+				"muted-foreground": "hsl(215.4 16.3% 46.9%)",
+				background: "hsl(0 0% 100%)",
+
 				abeg: {
 					button: {
-						10: '#1C8384',
-						20: '#005E5F',
+						10: "#1C8384",
+						20: "#005E5F",
 					},
 					teal: {
-						DEFAULT: '#268384',
-						10: '#2B908E',
+						DEFAULT: "#268384",
+						10: "#2B908E",
 					},
 					green: {
-						DEFAULT: '#324823',
-						20: '#7C946B',
-						30: '#C9DDBB',
-						40: '#F4FAF0',
-						50: '#007004',
-						60: '#006004',
+						DEFAULT: "#324823",
+						20: "#7C946B",
+						30: "#C9DDBB",
+						40: "#F4FAF0",
+						50: "#007004",
+						60: "#006004",
 					},
 					neutral: {
-						10: '#101E14',
-						20: '#344639',
-						30: '#4E5F53',
-						40: '#748178',
-						50: '#A1AAA4',
-						60: '#CDD6D0',
-						70: '#E3E8E5',
-						80: '#F4F5F5',
+						10: "#101E14",
+						20: "#344639",
+						30: "#4E5F53",
+						40: "#748178",
+						50: "#A1AAA4",
+						60: "#CDD6D0",
+						70: "#E3E8E5",
+						80: "#F4F5F5",
 					},
 					error: {
-						10: '#6A0101',
-						20: '#FC3131',
-						30: '#FEDCDC',
-						40: '#FFEBEB',
+						10: "#6A0101",
+						20: "#FC3131",
+						30: "#FEDCDC",
+						40: "#FFEBEB",
 					},
 				},
 			},
-			height: {
-				'23': '6rem',
-			},
+
 			keyframes: {
-				'accordion-down': {
-					from: {height: '0'},
-					to: {height: 'var(--radix-accordion-content-height)'},
+				"accordion-down": {
+					from: { height: "0" },
+					to: { height: "var(--radix-accordion-content-height)" },
 				},
-				'accordion-up': {
-					from: {height: 'var(--radix-accordion-content-height)'},
-					to: {height: '0'},
+				"accordion-up": {
+					from: { height: "var(--radix-accordion-content-height)" },
+					to: { height: "0" },
+				},
+				shake: {
+					"0%, 100%": { transform: "translateX(0rem)" },
+					"25%": { transform: "translateX(0.6rem)" },
+					"75%": { transform: "translateX(-0.6rem)" },
 				},
 			},
+
 			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out',
+				"accordion-down": "accordion-down 0.2s ease-out",
+				"accordion-up": "accordion-up 0.2s ease-out",
+				shake: "shake 0.2s ease-in-out 0s 3",
 			},
 		},
 	},
-	safelist: [
-		{
-			pattern: /text-(sm|base|lg|xl|2xl)/,
-		},
-	],
+
 	plugins: [
-		require('tailwindcss-animate'),
-		plugin(function ({addVariant}) {
-			addVariant('progress-unfilled', ['&::-webkit-progress-bar', '&'])
-			addVariant('progress-filled', [
-				'&::-webkit-progress-value',
-				'&::-moz-progress-bar',
-				'&',
-			])
+		require("tailwindcss-animate"),
+		require("@tailwindcss/typography"),
+		plugin(function ({ addVariant, addComponents, theme }) {
+			addVariant("progress-unfilled", ["&::-webkit-progress-bar", "&"]);
+			addVariant("progress-filled", [
+				"&::-webkit-progress-value",
+				"&::-moz-progress-bar",
+				"&",
+			]);
+
+			addComponents({
+				".custom-scrollbar": {
+					"&::-webkit-scrollbar": {
+						width: "1rem",
+					},
+
+					"&::-webkit-scrollbar-track": {
+						backgroundColor: "hsl(0, 0%, 76%)",
+						borderRadius: "1rem 1rem 0 0",
+					},
+
+					"&::-webkit-scrollbar-thumb": {
+						backgroundColor: theme("colors.formBtn"),
+						border: "1px solid hsl(0, 0%, 76%)",
+						borderRadius: "1rem",
+					},
+				},
+			});
 		}),
 	],
-}
-export default config
+} satisfies Config;
+
+export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -58,6 +58,10 @@ const config = {
 				"3xl": "2000px",
 			},
 
+			height: {
+				"23": "6rem",
+			},
+
 			backgroundImage: {
 				contours: "url('/assets/images/shared/bg-contours.png')",
 				"contours-old": "url('/assets/images/shared/contours-old.png')",


### PR DESCRIPTION
## Description
- Added design tokens to tailwind config in rem format
- Added 1rem : 10px ratio mapping for rem to px calculation in global css
- Added setting in vscode workspace to show rem values in the 1rem : 10px ratio
- Added custom tailwind config support to the cn utility

## Related Issue

- Fixes -

## Checklist

- [x] I have reviewed the Contribution Guidelines linked above.
- [x] I have tested my changes thoroughly and ensured that all existing tests pass.
- [x] I have provided clear and concise commit messages.
- [x] I have updated the project's documentation as necessary.

